### PR TITLE
changed string boolean to normal boolen to avoid deprecation warnings from Matplotlib

### DIFF
--- a/power_ranker/web/radar.py
+++ b/power_ranker/web/radar.py
@@ -15,7 +15,7 @@ class Radar(object):
     self.ax.set_thetagrids(self.angles, labels=titles, fontsize=12, weight='bold')
     for ax in self.axes[1:]:
       ax.patch.set_visible(False)
-      ax.grid("off")
+      ax.grid(False)
       ax.xaxis.set_visible(False)
     for ax, angle, label in zip(self.axes, self.angles, labels):
       ax.set_rgrids(range(1, 6), angle=angle, labels=label)


### PR DESCRIPTION
Matplotlib is throwing a deprecation warning due to line 18 in `power_ranker/web/radar.py`:  
   
```
/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/cbook/deprecation.py:107: MatplotlibDeprecationWarning: Passing one of 'on', 'true', 'off', 'false' as a boolean is deprecated; use an actual boolean (True/False) instead.
  warnings.warn(message, mplDeprecation, stacklevel=1)
```
  
  
To fix this I changed the line:  
`ax.grid("off")`   
to  
`ax.grid(False)`